### PR TITLE
feat: 日付エンコーディング戦略の統一とencodeメソッド追加

### DIFF
--- a/Sources/APIClient/APIClient.swift
+++ b/Sources/APIClient/APIClient.swift
@@ -15,6 +15,13 @@ import Foundation
 ///
 /// - Note: このプロトコルに準拠する実装は`Sendable`である必要があります
 public protocol APIClient: Sendable {
+    /// オブジェクトをJSONデータにエンコードする
+    /// APIClientの日付エンコーディング戦略が適用される
+    /// - Parameter value: エンコードする値
+    /// - Returns: エンコードされたJSONデータ
+    /// - Throws: エンコードエラー
+    func encode<T: Encodable>(_ value: T) throws -> Data
+
     /// レスポンスをデコードしてジェネリック型として返すリクエストメソッド
     /// - Parameter endpoint: リクエスト情報を含むエンドポイント
     /// - Returns: デコードされたレスポンスオブジェクト


### PR DESCRIPTION
## 概要
APIClientで日付エンコーディング/デコーディング戦略を統一し、リポジトリ層で使いやすくするための改善

## 変更内容

### APIClientプロトコル
- `encode<T: Encodable>(_ value: T) throws -> Data` メソッドを追加
- リポジトリ層でAPIClientの日付戦略を使ってエンコード可能に

### APIClientImpl
- 初期化時に内部的に`JSONEncoder`と`JSONDecoder`を設定
- `dateEncodingStrategy`と`dateDecodingStrategy`をコンストラクタで受け取り
- デフォルトの日付戦略を提供

### 日付戦略
**エンコーディング（送信時）：**
- RFC3339形式（`2024-01-15T10:30:00Z`）
- フラクショナル秒なし

**デコーディング（受信時）：**
- RFC3339形式
- RFC3339+フラクショナル秒形式（フォールバック）
- date-only形式（`2024-01-15`）（フォールバック）

## 影響範囲
- リポジトリ層でのDTOエンコーディングが簡素化
- 日付フォーマットの一貫性向上
- バックエンドとの日付やり取りが統一

## テスト
- [ ] 既存のテストが通ることを確認
- [ ] 日付エンコーディングが正しいフォーマットになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)