### PR TITLE
chore: swift-api-contract を 1.1.1 に固定

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", .upToNextMajor(from: "1.4.0")),
-        .package(url: "https://github.com/no-problem-dev/swift-api-contract.git", from: "1.1.0")
+        .package(path: "../swift-api-contract")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", .upToNextMajor(from: "1.4.0")),
-        .package(path: "../swift-api-contract")
+        .package(url: "https://github.com/no-problem-dev/swift-api-contract.git", from: "1.1.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

`swift-api-contract` の依存制約を `from: "1.1.0"` → `from: "1.1.1"` に変更。1.1.1 で `AuthScheme.required` のエイリアス追加が含まれるため、それを含む最小バージョンに固定する。

## Test
- `swift build`: ✅ Build complete!