### PR TITLE
fix: Linux ビルド互換性 - FoundationNetworking + SSE Darwin 限定化

### DIFF
--- a/Sources/APIClient/APIClientImpl.swift
+++ b/Sources/APIClient/APIClientImpl.swift
@@ -1,5 +1,8 @@
 import APIContract
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// APIクライアント実装
 public struct APIClientImpl: APIClient {

--- a/Sources/APIClient/SSE/SSEClient+StreamingAPI.swift
+++ b/Sources/APIClient/SSE/SSEClient+StreamingAPI.swift
@@ -1,6 +1,10 @@
 import Foundation
 import APIContract
 
+// SSEClientImpl is Darwin-only (see SSEClientImpl.swift) — this extension
+// follows the same compile guard so it only exists on Darwin.
+#if canImport(Darwin)
+
 // MARK: - StreamingAPIExecutable Implementation
 
 extension SSEClientImpl: StreamingAPIExecutable {
@@ -67,3 +71,5 @@ extension SSEClientImpl: StreamingAPIExecutable {
         }
     }
 }
+
+#endif // canImport(Darwin)

--- a/Sources/APIClient/SSE/SSEClientImpl.swift
+++ b/Sources/APIClient/SSE/SSEClientImpl.swift
@@ -1,6 +1,12 @@
 import APIContract
 import Foundation
 
+// SSEClientImpl uses URLSession.AsyncBytes (session.bytes(for:)), which is
+// only available on Darwin platforms. On Linux (e.g. Cloud Run server builds),
+// this type is conditionally compiled out — server code uses HTTPStreamingClient
+// from swift-llm-cloud instead.
+#if canImport(Darwin)
+
 /// Server-Sent Events (SSE) client implementation
 ///
 /// Connects to SSE endpoints and streams events as they arrive.
@@ -318,6 +324,8 @@ public struct SSEClientImpl: SSEClient, Sendable {
         return SSEEvent(data: data, event: event, id: id, retry: retry)
     }
 }
+
+#endif // canImport(Darwin)
 
 // MARK: - Helper Types
 


### PR DESCRIPTION
## Summary
- APIClientImpl.swift に `#if canImport(FoundationNetworking)` で FoundationNetworking import を追加
- SSEClientImpl.swift と SSEClient+StreamingAPI.swift を `#if canImport(Darwin)` で Darwin 限定化（`session.bytes(for:)` が Linux 非対応）
- これで Cloud Run の Swift Linux ビルドで APIClient 依存が通るようになる

## Context
reading-memory の Cloud Run デプロイで `swift build -c release` が swift-api-client の Linux 非互換コードで失敗していた。Server 側は SSE 消費側ではなく提供側なので SSEClientImpl は必要ない。

## Test plan
- [x] macOS で `swift build` 成功を確認
- [ ] Cloud Run デプロイで swift-llm-cloud → swift-api-client 経由でビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)